### PR TITLE
removed leading ":" to get a valid XML file

### DIFF
--- a/instances/Grid/cimxml/Nordic44-HV_GL.xml
+++ b/instances/Grid/cimxml/Nordic44-HV_GL.xml
@@ -1,4 +1,4 @@
-:<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF  xmlns:cim="http://iec.ch/TC57/CIM100#" 
 		xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" 
 		xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"


### PR DESCRIPTION
Hi,
GL was not a valid XML.
There was a ":" at the beginning. 

Try to make it via a pullrequest but can also open an issue for you.

Thanks,
Martin